### PR TITLE
Hitstory download tasks

### DIFF
--- a/stockdb/api/models.py
+++ b/stockdb/api/models.py
@@ -9,6 +9,7 @@ class APITags(Enum):
     per_security = "Per Security"
     bulk = "Bulk"
     dataset = "Dataset"
+    task = "Task"
 
 
 class Period(Enum):
@@ -96,6 +97,16 @@ class DBTableName(Enum):
 class SuperTrendRecentNDatasetFormat(Enum):
     detail = "detail"
     ticker_only = "tickers-only"
+
+
+class TickerHistoryDownloadMode(Enum):
+    full = "full"
+    incremental = "incremental"
+
+
+class TaskMode(Enum):
+    auto = "auto"
+    manual = "manual"
 
 
 class YahooTickerIdentifier(BaseModel):
@@ -235,6 +246,81 @@ class TickerInput(BaseModel):
                 symbol=t,
                 exchange=exchange.name,
                 exch_id=getattr(StockExchangeYahooIdentifier, exchange.name),
+            )
+            for t in self.ticker
+        ]
+
+
+class TaskTickerHistoryDownloadInput(BaseModel):
+    exchange: StockExchange = Field(
+        StockExchange.nse, description="Stock Exchange to download ticker history for"
+    )
+    task_mode: TaskMode = Field(TaskMode.auto, description="Mode of task execution")
+    download_mode: TickerHistoryDownloadMode = Field(
+        TickerHistoryDownloadMode.incremental,
+        description="Download mode. `full` mode downloads complete history. `incremental` mode downloads only latest/missing data.",
+    )
+    ticker: list[str] | None = Field(
+        None,
+        description="Desired company's `Ticker` symbol. If not provided, all tickers in the exchange will be processed.",
+        examples=[
+            ["infy", "tcs", "AKASH"],
+            ["AAPL", "msft"],
+        ],
+    )
+    start_date: date | None = Field(
+        None,
+        description="Start date for historical data points. Only used in `manual` mode.",
+        examples=["2024-01-01", "2021-01-01"],
+    )
+    end_date: date | None = Field(
+        None,
+        description="End date for historical data points. Only used in `manual` mode.",
+        examples=["2024-02-01", "2021-01-31"],
+    )
+
+    @model_validator(mode="after")
+    def validate_manual_mode_dates(self):
+        # In auto mode, start_date and end_date should not be provided
+        if self.task_mode == TaskMode.auto and (
+            self.start_date is not None or self.end_date is not None
+        ):
+            raise ValueError(
+                "start_date and end_date should not be provided in auto mode"
+            )
+        if self.task_mode == TaskMode.manual:
+            if self.start_date is None or self.end_date is None:
+                raise ValueError("start_date and end_date are required in manual mode")
+            if self.start_date > self.end_date:
+                raise ValueError("start_date must be less than end_date")
+        return self
+
+    def get_yahoo_aware_ticker(self) -> list[YahooTickerIdentifier]:
+        """Get Ticker wrt to yahoo aware exchange."""
+        if self.ticker is None:
+            from polars import scan_delta
+
+            from api.config import Settings
+
+            settings = Settings()
+
+            self.ticker = (
+                scan_delta(settings.stockdb.data_base_path / "common/security")
+                .select(self.exchange.value)
+                .explode(self.exchange.value)
+                .collect()
+                .to_series()
+                .to_list()
+            )
+            raise ValueError("Ticker list is None. Cannot get Yahoo aware ticker.")
+        self.ticker = [
+            t.upper() for t in self.ticker
+        ]  # making sure that ticker symbol are always Upper case
+        return [
+            YahooTickerIdentifier(
+                symbol=t,
+                exchange=self.exchange.name,
+                exch_id=getattr(StockExchangeYahooIdentifier, self.exchange.name),
             )
             for t in self.ticker
         ]

--- a/stockdb/api/models.py
+++ b/stockdb/api/models.py
@@ -174,12 +174,12 @@ class TickerHistoryQuery(BaseModel):
         Period.ONE_DAY,
         description="Day period between historical data points. This is mutually exclusive with `start_date` and `end_date`",
     )
-    start_date: date = Field(
+    start_date: date | None = Field(
         None,
         description="Start date for historical data points. This is mutually exclusive with `period`",
         examples=["2024-01-01", "2020-12-31"],
     )
-    end_date: date = Field(
+    end_date: date | None = Field(
         None,
         description="End date for historical data points. This is mutually exclusive with `period`",
         examples=["2024-02-01", "2021-01-31"],
@@ -312,7 +312,7 @@ class TaskTickerHistoryDownloadInput(BaseModel):
                 .to_series()
                 .to_list()
             )
-            raise ValueError("Ticker list is None. Cannot get Yahoo aware ticker.")
+
         self.ticker = [
             t.upper() for t in self.ticker
         ]  # making sure that ticker symbol are always Upper case

--- a/stockdb/api/routers/tasks.py
+++ b/stockdb/api/routers/tasks.py
@@ -19,7 +19,7 @@ settings = Settings()
 router = APIRouter(prefix="/api/task", tags=[APITags.task])
 
 
-@router.post("/ticker-history")
+@router.post("/ticker/history")
 async def daily_ticker_history_download(task_input: TaskTickerHistoryDownloadInput):
     """Trigger daily ticker history download for all tickers in given exchange"""
     # SECTION 1- Auto mode

--- a/stockdb/api/routers/tasks.py
+++ b/stockdb/api/routers/tasks.py
@@ -1,0 +1,77 @@
+from datetime import date
+
+import polars as pl
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import ORJSONResponse
+from pipeline.ticker_history_data_download import download_ticker_history
+
+from api.config import Settings
+from api.data import StockDataDB
+from api.models import (
+    APITags,
+    TaskMode,
+    TaskTickerHistoryDownloadInput,
+    TickerHistoryDownloadMode,
+)
+
+settings = Settings()
+
+router = APIRouter(prefix="/api/task", tags=[APITags.task])
+
+
+@router.post("/ticker-history")
+async def daily_ticker_history_download(task_input: TaskTickerHistoryDownloadInput):
+    """Trigger daily ticker history download for all tickers in given exchange"""
+    # SECTION 1- Auto mode
+    if task_input.task_mode == TaskMode.auto:
+        # checking if download is actually needed
+        stock_db = StockDataDB(
+            settings.stockdb.data_base_path
+            / f"{task_input.exchange.value}/ticker_history"
+        )
+        date_check = (
+            await stock_db.polars_filter(
+                pl.col("date").max().cast(pl.Date) < date.today()
+            )
+            .select("close")
+            .count()
+            .collect_async()
+        )
+
+        if date_check.item() == 0:
+            # No new data to download
+            return {"message": "No new data to download"}
+        # Trigger the download task for all tickers in the exchange
+        # REVIEW - IF we dont want to wait for result here, then fastapi background task should be used
+        # background_tasks.add_task(download_ticker_history, exchange=task_input.exchange)
+        if task_input.download_mode == TickerHistoryDownloadMode.incremental:
+            result = await download_ticker_history(exchange=task_input.exchange)
+            return ORJSONResponse(result)
+        # TODO - implement full download mode
+        if task_input.download_mode == TickerHistoryDownloadMode.full:
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail="Full download mode in auto mode is not implemented yet",
+            )
+
+    # SECTION 2 - Manual mode
+    elif task_input.task_mode == TaskMode.manual:
+        # SECTION 2.1 - Manual mode with full data history download
+        if task_input.download_mode == TickerHistoryDownloadMode.full:
+            # TODO - implement full download mode
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail="Full download mode in manual mode is not implemented yet",
+            )
+            # tickers = [f"{t.symbol}{t.exch_id}" for t in task_input.get_yahoo_aware_ticker()]
+            # # background_tasks.add_task(download_entire_ticker_history, task_input.exchange, tickers)
+            # data = await download_entire_ticker_history(task_input.exchange, tickers)
+        elif task_input.download_mode == TickerHistoryDownloadMode.incremental:
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail="Incremental download mode is not supported in manual mode",
+            )
+            # SECTION 2.2 - Manual mode with specific date range download
+            # tickers = [
+            #     f"{t.symbol}{t.exch_id}" for t in task_input.get_yahoo_aware_ticker()
+            # ]

--- a/stockdb/main.py
+++ b/stockdb/main.py
@@ -5,7 +5,7 @@ import traceback
 from about_time import about_time
 from api.config import Settings
 from api.models import APITags
-from api.routers import per_security
+from api.routers import per_security, tasks
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from scalar_fastapi import get_scalar_api_reference
@@ -14,7 +14,7 @@ logger = logging.getLogger("stockdb")
 settings = Settings()
 
 app = FastAPI(
-    debug=True, title="StockDB API", version="0.0.3", docs_url=None, redoc_url=None
+    debug=True, title="StockDB API", version="0.1.3", docs_url=None, redoc_url=None
 )
 
 
@@ -58,8 +58,9 @@ async def _index():
     return {"message": "StockDB API is up and running"}
 
 
-# adding all the routers from submodules wrt to v2 model
+# adding all the routers from submodules
 app.include_router(per_security.router, tags=[APITags.per_security])
+app.include_router(tasks.router, tags=[APITags.task])
 
 
 # Scalar interactive docs

--- a/stockdb/tests/test_models.py
+++ b/stockdb/tests/test_models.py
@@ -1,0 +1,223 @@
+from datetime import date
+
+import pytest
+from api.models import (
+    StockExchange,
+    StockExchangeYahooIdentifier,
+    TaskMode,
+    TaskTickerHistoryDownloadInput,
+    TickerHistoryDownloadMode,
+    YahooTickerIdentifier,
+)
+from pydantic import ValidationError
+
+
+@pytest.mark.parametrize(
+    "exchange,mode,ticker,start_date,end_date,download_mode,expected_tickers",
+    [
+        # Happy path: auto mode, no dates, tickers provided
+        (
+            StockExchange.nse,
+            TaskMode.auto,
+            ["infy", "tcs", "AKASH"],
+            None,
+            None,
+            TickerHistoryDownloadMode.incremental,
+            ["INFY", "TCS", "AKASH"],
+        ),
+        # Happy path: manual mode, dates provided, tickers provided
+        (
+            StockExchange.bse,
+            TaskMode.manual,
+            ["reliance", "hdfc"],
+            date(2024, 1, 1),
+            date(2024, 2, 1),
+            TickerHistoryDownloadMode.full,
+            ["RELIANCE", "HDFC"],
+        ),
+        # Happy path: manual mode, start_date == end_date
+        (
+            StockExchange.nasdaq,
+            TaskMode.manual,
+            ["aapl"],
+            date(2023, 5, 5),
+            date(2023, 5, 5),
+            TickerHistoryDownloadMode.incremental,
+            ["AAPL"],
+        ),
+    ],
+    ids=[
+        "auto_mode_valid_tickers",
+        "manual_mode_valid_dates_and_tickers",
+        "manual_mode_same_start_end_date",
+    ],
+)
+def test_task_ticker_history_download_input_happy_paths(
+    exchange, mode, ticker, start_date, end_date, download_mode, expected_tickers
+):
+    # Arrange
+
+    # Act
+    input_obj = TaskTickerHistoryDownloadInput(
+        exchange=exchange,
+        task_mode=mode,
+        ticker=list(ticker) if ticker is not None else None,
+        start_date=start_date,
+        end_date=end_date,
+        download_mode=download_mode,
+    )
+    yahoo_tickers = input_obj.get_yahoo_aware_ticker(exchange)
+
+    # Assert
+    assert [yt.symbol for yt in yahoo_tickers] == expected_tickers
+    assert all(isinstance(yt, YahooTickerIdentifier) for yt in yahoo_tickers)
+    assert all(yt.exchange == exchange.name for yt in yahoo_tickers)
+    assert all(
+        yt.exch_id == getattr(StockExchangeYahooIdentifier, exchange.name)
+        for yt in yahoo_tickers
+    )
+
+
+@pytest.mark.parametrize(
+    "mode,start_date,end_date,expected_error,expected_msg",
+    [
+        # Error: auto mode with start_date
+        (
+            TaskMode.auto,
+            date(2024, 1, 1),
+            None,
+            ValidationError,
+            "start_date and end_date should not be provided in auto mode",
+        ),
+        # Error: auto mode with end_date
+        (
+            TaskMode.auto,
+            None,
+            date(2024, 2, 1),
+            ValidationError,
+            "start_date and end_date should not be provided in auto mode",
+        ),
+        # Error: auto mode with both dates
+        (
+            TaskMode.auto,
+            date(2024, 1, 1),
+            date(2024, 2, 1),
+            ValidationError,
+            "start_date and end_date should not be provided in auto mode",
+        ),
+        # Error: manual mode, missing start_date
+        (
+            TaskMode.manual,
+            None,
+            date(2024, 2, 1),
+            ValidationError,
+            "start_date and end_date are required in manual mode",
+        ),
+        # Error: manual mode, missing end_date
+        (
+            TaskMode.manual,
+            date(2024, 1, 1),
+            None,
+            ValidationError,
+            "start_date and end_date are required in manual mode",
+        ),
+        # Error: manual mode, start_date > end_date
+        (
+            TaskMode.manual,
+            date(2024, 2, 2),
+            date(2024, 2, 1),
+            ValidationError,
+            "start_date must be less than end_date",
+        ),
+    ],
+    ids=[
+        "auto_mode_with_start_date",
+        "auto_mode_with_end_date",
+        "auto_mode_with_both_dates",
+        "manual_mode_missing_start_date",
+        "manual_mode_missing_end_date",
+        "manual_mode_start_date_gt_end_date",
+    ],
+)
+def test_task_ticker_history_download_input_invalid_dates(
+    mode, start_date, end_date, expected_error, expected_msg
+):
+    # Arrange
+
+    # Act & Assert
+    with pytest.raises(expected_error) as exc_info:
+        TaskTickerHistoryDownloadInput(
+            exchange=StockExchange.nse,
+            task_mode=mode,
+            ticker=["infy"],
+            start_date=start_date,
+            end_date=end_date,
+            download_mode=TickerHistoryDownloadMode.incremental,
+        )
+    # Assert
+    assert expected_msg in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "ticker,expected_error,expected_msg",
+    [
+        # Error: ticker is None
+        (None, ValueError, "Ticker list is None. Cannot get Yahoo aware ticker."),
+        # Error: ticker is empty list
+        ([], [], None),  # Should not raise, just return empty list
+    ],
+    ids=[
+        "ticker_none_raises",
+        "ticker_empty_returns_empty",
+    ],
+)
+def test_get_yahoo_aware_ticker_edge_cases(ticker, expected_error, expected_msg):
+    # Arrange
+    input_obj = TaskTickerHistoryDownloadInput(
+        exchange=StockExchange.nse,
+        task_mode=TaskMode.auto,
+        ticker=ticker if ticker is not None else None,
+        start_date=None,
+        end_date=None,
+        download_mode=TickerHistoryDownloadMode.incremental,
+    )
+
+    # Act & Assert
+    if expected_error:
+        with pytest.raises(expected_error) as exc_info:
+            input_obj.get_yahoo_aware_ticker(StockExchange.nse)
+        assert expected_msg in str(exc_info.value)
+    else:
+        result = input_obj.get_yahoo_aware_ticker(StockExchange.nse)
+        assert result == []
+
+
+@pytest.mark.parametrize(
+    "tickers,expected_upper",
+    [
+        (["infy", "TCS", "Akash"], ["INFY", "TCS", "AKASH"]),
+        (["aapl", "msft"], ["AAPL", "MSFT"]),
+        (["RELIANCE"], ["RELIANCE"]),
+    ],
+    ids=[
+        "mixed_case_tickers",
+        "lower_case_tickers",
+        "already_uppercase",
+    ],
+)
+def test_get_yahoo_aware_ticker_uppercase_conversion(tickers, expected_upper):
+    # Arrange
+    input_obj = TaskTickerHistoryDownloadInput(
+        exchange=StockExchange.nse,
+        task_mode=TaskMode.auto,
+        ticker=list(tickers),
+        start_date=None,
+        end_date=None,
+        download_mode=TickerHistoryDownloadMode.incremental,
+    )
+
+    # Act
+    result = input_obj.get_yahoo_aware_ticker(StockExchange.nse)
+
+    # Assert
+    assert [yt.symbol for yt in result] == expected_upper


### PR DESCRIPTION
## Overview
- Implemented new tasks router for downloading ticker history data
- Added support for auto download modes
- Introduced incremental download with date checking
- Updated API version to reflect new features

## Summary by Sourcery

Implement a new task-based router for downloading ticker history with configurable auto/manual execution and full/incremental modes, update API version and enums, and add validation and tests for the new download task model.

New Features:
- Add /api/task/ticker/history endpoint for triggering ticker history downloads
- Introduce TaskTickerHistoryDownloadInput model with auto/manual and full/incremental modes
- Implement incremental download flow in auto mode using download_ticker_history
- Support TaskMode and TickerHistoryDownloadMode enums for task configuration

Enhancements:
- Update API version to 0.1.3
- Extend APITags enum with 'Task' tag

Tests:
- Add unit tests for TaskTickerHistoryDownloadInput validation and ticker normalization