### PR TITLE
🔧 refactor: Improve version handling and type naming

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Stocksense-Core"
-version = "0.5.7"
+version = "0.5.8"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Akash Desarda", email = "desardaakash@gmail.com" }]

--- a/core/src/stocksense/__init__.py
+++ b/core/src/stocksense/__init__.py
@@ -1,11 +1,31 @@
 import logging
 import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from pathlib import Path
 
 from rich.console import Console
 from rich.logging import RichHandler
 
-__version__ = "0.5.7"
+
+def _get_version_from_dist(names=("Stocksense-Core", "stocksense-core", "stocksense")):
+    for n in names:
+        try:
+            return _dist_version(n)
+        except PackageNotFoundError:
+            continue
+    return None
+
+
+__version__ = (
+    _get_version_from_dist()
+    or (
+        (lambda: __import__(f"{__name__}._version", fromlist=["version"]).version)()
+        if True
+        else None
+    )
+    or "0.0.0"
+)
 
 # Setting logging
 logger = logging.getLogger("stocksense")

--- a/core/src/stocksense/data/yahoo.py
+++ b/core/src/stocksense/data/yahoo.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 import polars as pl
 import yfinance as yf
 
-from .types import Interval, Period, StockExchangeYahooIdentifier
+from stocksense.types import DataInterval, DataPeriod, StockExchangeYahooIdentifier
 
 logger = logging.getLogger("stocksense")
 
@@ -66,8 +66,8 @@ class YFStockData:
 
     def get_ticker_history(
         self,
-        period: Period | None = Period.FIVE_DAYS,
-        interval: Interval = Interval.ONE_DAY,
+        period: DataPeriod | None = DataPeriod.FIVE_DAYS,
+        interval: DataInterval = DataInterval.ONE_DAY,
         start: date | None = None,
         end: date | None = None,
     ) -> dict[str, pl.DataFrame]:

--- a/core/src/stocksense/types.py
+++ b/core/src/stocksense/types.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Period(Enum):
+class DataPeriod(Enum):
     ONE_DAY = "1d"
     FIVE_DAYS = "5d"
     ONE_MONTH = "1mo"
@@ -15,7 +15,7 @@ class Period(Enum):
     MAX = "max"
 
 
-class Interval(Enum):
+class DataInterval(Enum):
     ONE_MINUTE = "1m"
     TWO_MINUTES = "2m"
     FIVE_MINUTES = "5m"

--- a/core/tests/test_version.py
+++ b/core/tests/test_version.py
@@ -1,0 +1,39 @@
+"""Tests for version consistency.
+
+Ensure the in-package __version__ matches the `project.version` in pyproject.toml
+when running tests from the repository. If `pyproject.toml` cannot be found the test
+will be skipped (useful when running against an installed package where the file
+is not available).
+"""
+
+from pathlib import Path
+
+import pytest
+import tomllib
+from stocksense import __version__
+
+
+def _find_pyproject(start: Path) -> Path | None:
+    """Search up the directory tree for pyproject.toml starting at `start`."""
+    for parent in [start] + list(start.parents):
+        candidate = parent / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def test_version_matches_pyproject() -> None:
+    pyproject = _find_pyproject(Path(__file__).resolve())
+    if pyproject is None:
+        pytest.skip(
+            "pyproject.toml not found in parent tree; skipping version match test"
+        )
+
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+
+    proj_version = data.get("project", {}).get("version")
+    assert proj_version is not None, "`project.version` is missing from pyproject.toml"
+    assert proj_version == __version__, (
+        f"Version mismatch: pyproject.toml has {proj_version!r} but stocksense.__version__ is {__version__!r}"
+    )

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -3184,7 +3184,7 @@ wheels = [
 
 [[package]]
 name = "stocksense-core"
-version = "0.5.5"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Rename Period and Interval enums to DataPeriod and DataInterval
Update import statements to reflect new type names
Implement dynamic version retrieval from package metadata
Add version consistency test to ensure pyproject.toml matches __version__
Bump package version to 0.5.8

## Summary by Sourcery

Refine public types and version management across the stocksense core package.

New Features:
- Expose DataPeriod and DataInterval enums at the top-level stocksense.types module for use across data sources.
- Derive the package __version__ dynamically from installed distribution metadata with a fallback mechanism.

Enhancements:
- Rename Period and Interval enums to DataPeriod and DataInterval for clearer semantics and reduced naming collisions.

Build:
- Bump Stocksense-Core project version to 0.5.8 and refresh the lockfile metadata.

Tests:
- Add a test ensuring stocksense.__version__ matches the project.version declared in pyproject.toml, skipping when the file is unavailable.