### PR TITLE
discover-strategy

### DIFF
--- a/.github/agents/agno-agentic-app-expert.agent.md
+++ b/.github/agents/agno-agentic-app-expert.agent.md
@@ -1,0 +1,41 @@
+---
+description: "Expert in developing agentic and multi-agent Python applications using Agno, including agents, teams, tools, memory, knowledge bases, and production integration patterns. Use when working with Agno, agent workflows, LLM apps, RAG, tool-calling, or debugging Agno-based systems."
+tools: [vscode/memory, vscode/askQuestions, execute/runNotebookCell, execute/getTerminalOutput, execute/killTerminal, execute/sendToTerminal, execute/runTask, execute/createAndRunTask, execute/runInTerminal, execute/runTests, execute/testFailure, read/getNotebookSummary, read/problems, read/readFile, read/viewImage, read/readNotebookCellOutput, read/terminalSelection, read/terminalLastCommand, read/getTaskOutput, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, web/fetch, web/githubRepo, web/githubTextSearch, pylance-mcp-server/pylanceDocString, pylance-mcp-server/pylanceDocuments, pylance-mcp-server/pylanceFileSyntaxErrors, pylance-mcp-server/pylanceImports, pylance-mcp-server/pylanceInstalledTopLevelModules, pylance-mcp-server/pylanceInvokeRefactoring, pylance-mcp-server/pylancePythonEnvironments, pylance-mcp-server/pylanceRunCodeSnippet, pylance-mcp-server/pylanceSettings, pylance-mcp-server/pylanceSyntaxErrors, pylance-mcp-server/pylanceUpdatePythonEnvironment, pylance-mcp-server/pylanceWorkspaceRoots, pylance-mcp-server/pylanceWorkspaceUserFiles, agno/query_docs_filesystem_agno, agno/search_agno, ms-python.python/getPythonEnvironmentInfo, ms-python.python/getPythonExecutableCommand, ms-python.python/configurePythonEnvironment, todo]
+model: GPT-5.4 (copilot)
+---
+# Python Agno Expert
+
+You are an expert in building agentic and multi-agent applications in Python using the Agno framework. You are strong at designing agent structure, selecting the right Agno primitives, integrating tools and knowledge sources, and turning prototypes into maintainable production code. Default to provider-agnostic Agno patterns unless the user explicitly asks for OpenAI, Anthropic, Google, or another provider.
+
+## Constraints
+
+- Prefer Agno-native patterns over custom orchestration when Agno already provides the capability.
+- Keep solutions scoped to Agno-based agentic systems, surrounding Python integration, and directly related application code.
+- Do not introduce unrelated framework migrations or broad refactors unless they are required to make the Agno solution work.
+- Ask concise clarification questions when a critical choice is underspecified, especially model provider, memory strategy, persistence layer, or deployment target.
+- When the user is asking to implement or fix behavior, edit code directly rather than staying purely advisory.
+
+## Approach
+
+1. Identify the concrete Agno surface involved: single agent, team, workflow, tools, memory, knowledge base, storage, API integration, or UI integration.
+2. Map the requirement to the smallest Agno abstraction that fits, and explain tradeoffs only when they change implementation choices.
+3. Prefer FastAPI service integration when architecture examples need a default deployment surface and the user has not chosen one.
+4. Reuse existing project structure and utilities before adding new abstractions.
+5. Implement or propose code that is idiomatic Agno, typed Python, and easy to test.
+6. Validate the slice with the narrowest useful check available, such as a focused run, test, or type check.
+
+## Output Format
+
+- Start with the recommended Agno approach in plain terms.
+- Provide the concrete code or edits needed.
+- Call out required configuration, environment variables, or provider dependencies.
+- Mention validation steps or residual risks if relevant.
+
+## Agno Focus Areas
+
+- Building single-agent and multi-agent systems with clear responsibilities.
+- Tool wiring, structured outputs, retries, and model/provider configuration.
+- Memory, session state, vector stores, and knowledge base integration.
+- RAG, document ingestion, retrieval strategy, and evaluation tradeoffs.
+- FastAPI, background jobs, CLI, and web app integration around Agno agents.
+- Debugging agent loops, prompt leakage, tool misuse, and state consistency issues.

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Stocksense-Core"
-version = "0.9.1"
+version = "0.10.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Akash Desarda", email = "desardaakash@gmail.com" }]
@@ -11,6 +11,7 @@ dependencies = [
     "orjson>=3.11.4",
     "polars[deltalake,pyarrow]>=1.38.1",
     "duckdb>=1.5.1",
+    "ta-lib>=0.6.8",
     "pystache>=0.6.8",
     "rich>=14.2.0",
     "sqlglot>=30.4.2",
@@ -18,12 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-data = [
-    "nsetools>=2.0.1",
-    "scipy>=1.16.3",
-    "ta-lib>=0.6.8",
-    "yfinance>=1.2.1",
-]
+data = ["nsetools>=2.0.1", "scipy>=1.16.3", "yfinance>=1.2.1"]
 ai = [
     "arize-phoenix-client>=1.29.0",
     "arize-phoenix-otel>=0.14.0",

--- a/core/src/stocksense/strategy/catalog/__init__.py
+++ b/core/src/stocksense/strategy/catalog/__init__.py
@@ -9,7 +9,16 @@ from pydantic import BaseModel
 CATALOG_DIR = Path(__file__).resolve().parent
 
 
+class ParentCatalog(Enum):
+    technical_analysis = "technical analysis"
+    # fundamental_analysis = "fundamental analysis"
+    # sentiment_analysis = "sentiment analysis"
+    # machine_learning = "machine learning"
+    # alternative_data = "alternative data"
+
+
 class CatalogCategory(Enum):
+    # Technical Analysis Categories
     trend = "trend"
     momentum = "momentum"
     volatility = "volatility"
@@ -76,7 +85,7 @@ class StrategyCatalog(BaseModel):
     """A catalog of trading strategies, loaded from YAML files."""
 
     name: str
-    parent: str
+    parent: ParentCatalog
     strategies: dict[str, StrategyDescriptor]
 
 
@@ -106,6 +115,19 @@ def list_strategies() -> list[StrategyDescriptor]:
     strategies = []
     for catalog in catalogs:
         strategies.extend(catalog.strategies.values())
+    return strategies
+
+
+def list_strategies_by_parent(parent: str | ParentCatalog) -> list[StrategyDescriptor]:
+    """List all strategies in the catalog that belong to a specific parent"""
+    if isinstance(parent, str):
+        parent = ParentCatalog(parent)
+
+    catalogs = list_catalog()
+    strategies = []
+    for catalog in catalogs:
+        if catalog.parent == parent:
+            strategies.extend(catalog.strategies.values())
     return strategies
 
 

--- a/core/src/stocksense/strategy/catalog/__init__.py
+++ b/core/src/stocksense/strategy/catalog/__init__.py
@@ -121,7 +121,15 @@ def list_strategies() -> list[StrategyDescriptor]:
 def list_strategies_by_parent(parent: str | ParentCatalog) -> list[StrategyDescriptor]:
     """List all strategies in the catalog that belong to a specific parent"""
     if isinstance(parent, str):
-        parent = ParentCatalog(parent)
+        normalized_parent = parent.strip().lower()
+        try:
+            parent = ParentCatalog(normalized_parent)
+        except ValueError as exc:
+            valid_values = ", ".join(p.value for p in ParentCatalog)
+            raise ValueError(
+                f"Invalid parent catalog '{parent}'. "
+                f"Expected one of: {valid_values}"
+            ) from exc
 
     catalogs = list_catalog()
     strategies = []

--- a/core/src/stocksense/strategy/catalog/momentum.yaml
+++ b/core/src/stocksense/strategy/catalog/momentum.yaml
@@ -1,6 +1,6 @@
 # Curated momentum strategy metadata for AI-assisted strategy selection.
 name: Momentum Strategy Catalog
-parent: Technical Analysis
+parent: technical analysis
 strategies:
   rsi:
     id: momentum.rsi

--- a/core/src/stocksense/strategy/catalog/overlap.yaml
+++ b/core/src/stocksense/strategy/catalog/overlap.yaml
@@ -1,6 +1,6 @@
 # Curated overlap-study metadata for AI-assisted strategy selection.
 name: Overlap Study Strategy Catalog
-parent: Technical Analysis
+parent: technical analysis
 strategies:
   bbands:
     id: overlap.bbands

--- a/core/src/stocksense/strategy/catalog/registry.py
+++ b/core/src/stocksense/strategy/catalog/registry.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Iterable
 
 from . import (
     CatalogCategory,
@@ -108,10 +107,10 @@ def filter_strategies(
     *,
     parent: ParentCatalog | str | None = None,
     category: CatalogCategory | str | None = None,
-    tags: Iterable[str] | None = None,
-    market_regimes: Iterable[MarketRegime | str] | None = None,
-    time_horizons: Iterable[TimeHorizon | str] | None = None,
-    required_columns: Iterable[str] | None = None,
+    tags: list[str] | None = None,
+    market_regimes: list[MarketRegime | str] | None = None,
+    time_horizons: list[TimeHorizon | str] | None = None,
+    required_columns: list[str] | None = None,
 ) -> tuple[StrategyDescriptor, ...]:
     """Filter strategies using the compiled registry indexes."""
 

--- a/core/src/stocksense/strategy/catalog/registry.py
+++ b/core/src/stocksense/strategy/catalog/registry.py
@@ -1,0 +1,189 @@
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+from . import (
+    CatalogCategory,
+    MarketRegime,
+    ParentCatalog,
+    StrategyCatalog,
+    StrategyDescriptor,
+    TimeHorizon,
+    list_catalog,
+    list_strategies,
+    list_strategies_by_parent,
+)
+
+
+@dataclass(frozen=True)
+class StrategyRegistry:
+    """Compiled runtime view of the strategy catalog."""
+
+    catalogs: tuple[StrategyCatalog, ...]
+    strategies: tuple[StrategyDescriptor, ...]
+    by_parent: dict[str, tuple[StrategyCatalog, ...]]
+    by_id: dict[str, StrategyDescriptor]
+    by_category: dict[CatalogCategory, tuple[StrategyDescriptor, ...]]
+    by_tag: dict[str, tuple[StrategyDescriptor, ...]]
+    by_market_regime: dict[MarketRegime, tuple[StrategyDescriptor, ...]]
+    by_time_horizon: dict[TimeHorizon, tuple[StrategyDescriptor, ...]]
+    by_required_column: dict[str, tuple[StrategyDescriptor, ...]]
+
+
+def build_registry() -> StrategyRegistry:
+    """Build a compiled registry from the loaded strategy catalogs."""
+
+    catalogs = list_catalog()
+    strategies = tuple(list_strategies())
+    by_parent_lists: dict[str, list[StrategyCatalog]] = {}
+    for catalog in catalogs:
+        by_parent_lists.setdefault(catalog.parent.value, []).append(catalog)
+
+    by_parent = {
+        parent: tuple(parent_catalogs)
+        for parent, parent_catalogs in by_parent_lists.items()
+    }
+
+    by_id = {strategy.id: strategy for strategy in strategies}
+
+    by_category_lists: dict[CatalogCategory, list[StrategyDescriptor]] = {}
+    for strategy in strategies:
+        by_category_lists.setdefault(strategy.category, []).append(strategy)
+
+    by_category = {
+        category: tuple(category_strategies)
+        for category, category_strategies in by_category_lists.items()
+    }
+
+    by_tag_lists: dict[str, list[StrategyDescriptor]] = {}
+    by_market_regime_lists: dict[MarketRegime, list[StrategyDescriptor]] = {}
+    by_time_horizon_lists: dict[TimeHorizon, list[StrategyDescriptor]] = {}
+    by_required_column_lists: dict[str, list[StrategyDescriptor]] = {}
+    for strategy in strategies:
+        for tag in strategy.tags:
+            by_tag_lists.setdefault(tag, []).append(strategy)
+        for market_regime in strategy.market_regimes:
+            by_market_regime_lists.setdefault(market_regime, []).append(strategy)
+        for time_horizon in strategy.time_horizons:
+            by_time_horizon_lists.setdefault(time_horizon, []).append(strategy)
+        for required_column in strategy.required_columns:
+            by_required_column_lists.setdefault(required_column, []).append(strategy)
+
+    by_tag = {
+        tag: tuple(tag_strategies) for tag, tag_strategies in by_tag_lists.items()
+    }
+    by_market_regime = {
+        market_regime: tuple(regime_strategies)
+        for market_regime, regime_strategies in by_market_regime_lists.items()
+    }
+    by_time_horizon = {
+        time_horizon: tuple(horizon_strategies)
+        for time_horizon, horizon_strategies in by_time_horizon_lists.items()
+    }
+    by_required_column = {
+        required_column: tuple(column_strategies)
+        for required_column, column_strategies in by_required_column_lists.items()
+    }
+
+    return StrategyRegistry(
+        catalogs=catalogs,
+        strategies=strategies,
+        by_parent=by_parent,
+        by_id=by_id,
+        by_category=by_category,
+        by_tag=by_tag,
+        by_market_regime=by_market_regime,
+        by_time_horizon=by_time_horizon,
+        by_required_column=by_required_column,
+    )
+
+
+@lru_cache()
+def get_registry() -> StrategyRegistry:
+    """Get the cached compiled strategy registry."""
+
+    return build_registry()
+
+
+def filter_strategies(
+    *,
+    parent: ParentCatalog | str | None = None,
+    category: CatalogCategory | str | None = None,
+    tags: Iterable[str] | None = None,
+    market_regimes: Iterable[MarketRegime | str] | None = None,
+    time_horizons: Iterable[TimeHorizon | str] | None = None,
+    required_columns: Iterable[str] | None = None,
+) -> tuple[StrategyDescriptor, ...]:
+    """Filter strategies using the compiled registry indexes."""
+
+    registry = get_registry()
+    strategies: tuple[StrategyDescriptor, ...] = registry.strategies
+
+    if parent is not None:
+        parent_strategy_ids = {
+            strategy.id for strategy in list_strategies_by_parent(parent)
+        }
+        strategies = tuple(
+            strategy for strategy in strategies if strategy.id in parent_strategy_ids
+        )
+
+    if category is not None:
+        if isinstance(category, str):
+            category = CatalogCategory(category)
+        category_strategy_ids = {
+            strategy.id for strategy in registry.by_category.get(category, ())
+        }
+        strategies = tuple(
+            strategy for strategy in strategies if strategy.id in category_strategy_ids
+        )
+
+    if tags is not None:
+        for tag in tags:
+            tag_strategy_ids = {
+                strategy.id for strategy in registry.by_tag.get(tag, ())
+            }
+            strategies = tuple(
+                strategy for strategy in strategies if strategy.id in tag_strategy_ids
+            )
+
+    if market_regimes is not None:
+        for market_regime in market_regimes:
+            if isinstance(market_regime, str):
+                market_regime = MarketRegime(market_regime)
+            regime_strategy_ids = {
+                strategy.id
+                for strategy in registry.by_market_regime.get(market_regime, ())
+            }
+            strategies = tuple(
+                strategy
+                for strategy in strategies
+                if strategy.id in regime_strategy_ids
+            )
+
+    if time_horizons is not None:
+        for time_horizon in time_horizons:
+            if isinstance(time_horizon, str):
+                time_horizon = TimeHorizon(time_horizon)
+            horizon_strategy_ids = {
+                strategy.id
+                for strategy in registry.by_time_horizon.get(time_horizon, ())
+            }
+            strategies = tuple(
+                strategy
+                for strategy in strategies
+                if strategy.id in horizon_strategy_ids
+            )
+
+    if required_columns is not None:
+        for required_column in required_columns:
+            column_strategy_ids = {
+                strategy.id
+                for strategy in registry.by_required_column.get(required_column, ())
+            }
+            strategies = tuple(
+                strategy
+                for strategy in strategies
+                if strategy.id in column_strategy_ids
+            )
+
+    return strategies

--- a/core/src/stocksense/strategy/catalog/registry.py
+++ b/core/src/stocksense/strategy/catalog/registry.py
@@ -133,7 +133,7 @@ def filter_strategies(
 
     if category is not None:
         if isinstance(category, str):
-            category = CatalogCategory(category)
+            category = CatalogCategory(category.strip().lower())
         category_strategy_ids = {
             strategy.id for strategy in registry.by_category.get(category, ())
         }

--- a/core/src/stocksense/strategy/catalog/registry.py
+++ b/core/src/stocksense/strategy/catalog/registry.py
@@ -11,7 +11,6 @@ from . import (
     TimeHorizon,
     list_catalog,
     list_strategies,
-    list_strategies_by_parent,
 )
 
 
@@ -21,7 +20,7 @@ class StrategyRegistry:
 
     catalogs: tuple[StrategyCatalog, ...]
     strategies: tuple[StrategyDescriptor, ...]
-    by_parent: dict[str, tuple[StrategyCatalog, ...]]
+    by_parent: dict[ParentCatalog, tuple[StrategyCatalog, ...]]
     by_id: dict[str, StrategyDescriptor]
     by_category: dict[CatalogCategory, tuple[StrategyDescriptor, ...]]
     by_tag: dict[str, tuple[StrategyDescriptor, ...]]
@@ -33,11 +32,11 @@ class StrategyRegistry:
 def build_registry() -> StrategyRegistry:
     """Build a compiled registry from the loaded strategy catalogs."""
 
-    catalogs = list_catalog()
+    catalogs = tuple(list_catalog())
     strategies = tuple(list_strategies())
-    by_parent_lists: dict[str, list[StrategyCatalog]] = {}
+    by_parent_lists: dict[ParentCatalog, list[StrategyCatalog]] = {}
     for catalog in catalogs:
-        by_parent_lists.setdefault(catalog.parent.value, []).append(catalog)
+        by_parent_lists.setdefault(catalog.parent, []).append(catalog)
 
     by_parent = {
         parent: tuple(parent_catalogs)
@@ -120,8 +119,13 @@ def filter_strategies(
     strategies: tuple[StrategyDescriptor, ...] = registry.strategies
 
     if parent is not None:
+        if isinstance(parent, str):
+            parent = ParentCatalog(parent.strip().lower())
+        parent_catalogs = registry.by_parent.get(parent, ())
         parent_strategy_ids = {
-            strategy.id for strategy in list_strategies_by_parent(parent)
+            strategy.id
+            for catalog in parent_catalogs
+            for strategy in catalog.strategies.values()
         }
         strategies = tuple(
             strategy for strategy in strategies if strategy.id in parent_strategy_ids

--- a/core/src/stocksense/strategy/catalog/trend.yaml
+++ b/core/src/stocksense/strategy/catalog/trend.yaml
@@ -1,7 +1,7 @@
 # Curated trend strategy metadata for AI-assisted strategy selection.
 # Contributors should keep field names stable so the Python loader can validate them.
 name: Trend Strategy Catalog
-parent: Technical Analysis
+parent: technical analysis
 strategies:
   sma_crossover:
     id: trend.sma_crossover

--- a/core/src/stocksense/strategy/catalog/volatility.yaml
+++ b/core/src/stocksense/strategy/catalog/volatility.yaml
@@ -1,6 +1,6 @@
 # Curated volatility strategy metadata for AI-assisted strategy selection.
 name: Volatility Strategy Catalog
-parent: Technical Analysis
+parent: technical analysis
 strategies:
   atr:
     id: volatility.atr

--- a/core/src/stocksense/strategy/catalog/volume.yaml
+++ b/core/src/stocksense/strategy/catalog/volume.yaml
@@ -1,6 +1,6 @@
 # Curated volume strategy metadata for AI-assisted strategy selection.
 name: Volume Strategy Catalog
-parent: Technical Analysis
+parent: technical analysis
 strategies:
   obv:
     id: volume.obv

--- a/core/tests/tests_strategy/test_catalog.py
+++ b/core/tests/tests_strategy/test_catalog.py
@@ -1,5 +1,4 @@
 import pytest
-
 from stocksense.strategy.catalog import (
     CatalogCategory,
     catalog_files,
@@ -23,9 +22,7 @@ def test_strategy_catalog_loads_all_yaml_files():
 
     strategies = list_strategies()
     assert strategies
-    assert len(strategies) == sum(
-        len(catalog.strategies) for catalog in catalogs
-    )
+    assert len(strategies) == sum(len(catalog.strategies) for catalog in catalogs)
 
 
 def test_strategy_catalog_required_fields_are_present():
@@ -54,9 +51,7 @@ def test_list_strategies_by_category_returns_only_matching_strategies(category):
     strategies = list_strategies_by_category(category)
 
     assert strategies
-    assert all(
-        strategy.category == CatalogCategory.trend for strategy in strategies
-    )
+    assert all(strategy.category == CatalogCategory.trend for strategy in strategies)
 
 
 def test_list_strategies_by_category_rejects_unknown_category():
@@ -73,9 +68,7 @@ def test_get_catalog_strategy_id_map_matches_loaded_strategies():
 
     for category, strategy_ids in category_map.items():
         expected_ids = [
-            strategy.id
-            for strategy in strategies
-            if strategy.category == category
+            strategy.id for strategy in strategies if strategy.category == category
         ]
         assert set(strategy_ids) == set(expected_ids)
         assert strategy_ids == expected_ids

--- a/core/tests/tests_strategy/test_catalog_registry.py
+++ b/core/tests/tests_strategy/test_catalog_registry.py
@@ -1,16 +1,17 @@
 from stocksense.strategy.catalog import (
     CatalogCategory,
     MarketRegime,
+    ParentCatalog,
     TimeHorizon,
     list_catalog,
     list_strategies,
+    list_strategies_by_parent,
 )
 from stocksense.strategy.catalog.registry import (
     StrategyRegistry,
     build_registry,
     filter_strategies,
     get_registry,
-    list_strategies_by_parent,
 )
 
 
@@ -33,12 +34,10 @@ def test_build_registry_indexes_catalogs_by_parent():
     registry = build_registry()
 
     for parent, catalogs in registry.by_parent.items():
-        assert all(catalog.parent.value == parent for catalog in catalogs)
+        assert all(catalog.parent == parent for catalog in catalogs)
 
-    assert set(registry.by_parent) == {
-        catalog.parent.value for catalog in registry.catalogs
-    }
-    assert "technical analysis" in registry.by_parent
+    assert set(registry.by_parent) == {catalog.parent for catalog in registry.catalogs}
+    assert ParentCatalog.technical_analysis in registry.by_parent
 
 
 def test_build_registry_indexes_strategies_by_id_and_category():
@@ -90,7 +89,7 @@ def test_list_strategies_by_parent_returns_matching_strategies():
     strategies = list_strategies_by_parent("technical analysis")
 
     assert strategies
-    assert strategies == tuple(list_strategies())
+    assert strategies == list(list_strategies())
 
 
 def test_filter_strategies_returns_intersection_of_registry_indexes():

--- a/core/tests/tests_strategy/test_catalog_registry.py
+++ b/core/tests/tests_strategy/test_catalog_registry.py
@@ -1,0 +1,107 @@
+from stocksense.strategy.catalog import (
+    CatalogCategory,
+    MarketRegime,
+    TimeHorizon,
+    list_catalog,
+    list_strategies,
+)
+from stocksense.strategy.catalog.registry import (
+    StrategyRegistry,
+    build_registry,
+    filter_strategies,
+    get_registry,
+    list_strategies_by_parent,
+)
+
+
+def test_build_registry_compiles_catalogs_and_indexes():
+    registry = build_registry()
+
+    assert isinstance(registry, StrategyRegistry)
+    assert registry.catalogs == list_catalog()
+    assert registry.strategies == tuple(list_strategies())
+    assert registry.by_parent
+    assert registry.by_id
+    assert registry.by_category
+    assert registry.by_tag
+    assert registry.by_market_regime
+    assert registry.by_time_horizon
+    assert registry.by_required_column
+
+
+def test_build_registry_indexes_catalogs_by_parent():
+    registry = build_registry()
+
+    for parent, catalogs in registry.by_parent.items():
+        assert all(catalog.parent.value == parent for catalog in catalogs)
+
+    assert set(registry.by_parent) == {
+        catalog.parent.value for catalog in registry.catalogs
+    }
+    assert "technical analysis" in registry.by_parent
+
+
+def test_build_registry_indexes_strategies_by_id_and_category():
+    registry = build_registry()
+
+    for strategy in registry.strategies:
+        assert registry.by_id[strategy.id] == strategy
+
+    for category, strategies in registry.by_category.items():
+        assert all(strategy.category == category for strategy in strategies)
+
+    assert set(registry.by_category) == {
+        strategy.category for strategy in registry.strategies
+    }
+    assert CatalogCategory.trend in registry.by_category
+
+
+def test_build_registry_indexes_strategies_by_tag_regime_horizon_and_column():
+    registry = build_registry()
+
+    for tag, strategies in registry.by_tag.items():
+        assert all(tag in strategy.tags for strategy in strategies)
+
+    for market_regime, strategies in registry.by_market_regime.items():
+        assert all(market_regime in strategy.market_regimes for strategy in strategies)
+
+    for time_horizon, strategies in registry.by_time_horizon.items():
+        assert all(time_horizon in strategy.time_horizons for strategy in strategies)
+
+    for required_column, strategies in registry.by_required_column.items():
+        assert all(
+            required_column in strategy.required_columns for strategy in strategies
+        )
+
+    assert "momentum" in registry.by_tag
+    assert MarketRegime.trending in registry.by_market_regime
+    assert TimeHorizon.swing in registry.by_time_horizon
+    assert "close" in registry.by_required_column
+
+
+def test_get_registry_returns_cached_registry_instance():
+    first_registry = get_registry()
+    second_registry = get_registry()
+
+    assert first_registry is second_registry
+
+
+def test_list_strategies_by_parent_returns_matching_strategies():
+    strategies = list_strategies_by_parent("technical analysis")
+
+    assert strategies
+    assert strategies == tuple(list_strategies())
+
+
+def test_filter_strategies_returns_intersection_of_registry_indexes():
+    strategies = filter_strategies(
+        parent="technical analysis",
+        category=CatalogCategory.momentum,
+        tags=["volume-confirmation"],
+        market_regimes=[MarketRegime.trending],
+        time_horizons=[TimeHorizon.swing],
+        required_columns=["volume"],
+    )
+
+    assert strategies
+    assert [strategy.id for strategy in strategies] == ["momentum.mfi"]

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -3235,7 +3235,7 @@ wheels = [
 
 [[package]]
 name = "stocksense-core"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -3246,6 +3246,7 @@ dependencies = [
     { name = "pystache" },
     { name = "rich" },
     { name = "sqlglot" },
+    { name = "ta-lib" },
     { name = "toml" },
 ]
 
@@ -3262,7 +3263,6 @@ ai = [
 data = [
     { name = "nsetools" },
     { name = "scipy" },
-    { name = "ta-lib" },
     { name = "yfinance" },
 ]
 
@@ -3291,7 +3291,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "scipy", marker = "extra == 'data'", specifier = ">=1.16.3" },
     { name = "sqlglot", specifier = ">=30.4.2" },
-    { name = "ta-lib", marker = "extra == 'data'", specifier = ">=0.6.8" },
+    { name = "ta-lib", specifier = ">=0.6.8" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "yfinance", marker = "extra == 'data'", specifier = ">=1.2.1" },
 ]

--- a/stock-research-platform.code-workspace
+++ b/stock-research-platform.code-workspace
@@ -76,8 +76,19 @@
 		"editor.fontFamily": "'Monaspace Argon NF', monospace",
 		"ruff.format.preview": true,
 		"ruff.organizeImports": true,
-		"terminal.integrated.fontFamily": "'Monaspace Argon NF'",
-		"terminal.integrated.fontLigatures.enabled": true
+		"mcp": {
+			"servers": {
+				"llama_index_docs": {
+					"url": "https://developers.llamaindex.ai/mcp",
+					"type": "http"
+				},
+				"agno": {
+					"url": "https://docs.agno.com/mcp",
+					"type": "http"
+				}
+			},
+			"inputs": []
+		}
 	},
 	"tasks": {
 		"version": "2.0.0",
@@ -114,7 +125,7 @@
 					"$python"
 				]
 			}
-		],
+		]
 	},
 	"launch": {
 		"version": "0.2.0",
@@ -125,7 +136,6 @@
 				"request": "launch",
 				"program": "${workspaceFolder}/webapp/.venv/Scripts/streamlit.exe",
 				"args": [
-					// "uv",
 					"run",
 					"${workspaceFolder}/webapp/main.py"
 				],


### PR DESCRIPTION
# Important Changes

- Added compiled `StrategyRegistry` as a frozen dataclass with aggregated and indexed views
- Implemented `build_registry` function to construct multiple indexed views
- Added strategies helper with filtering capabilities by parent, category, tags, market_regimes, time_horizons, and required_columns
- Normalized parent field to lowercase
- Added comprehensive test suite for strategy catalog registry including building, indexing, caching, and filtering tests

## Summary by Sourcery

Introduce a compiled, queryable strategy registry over the strategy catalog to support indexed lookup and filtered discovery of trading strategies.

New Features:
- Add ParentCatalog enum to represent parent catalog types and expose listing strategies by parent.
- Create a StrategyRegistry dataclass with multiple precomputed indexes over catalogs and strategies.
- Provide a build_registry helper and cached get_registry accessor for constructing the compiled registry.
- Add a filter_strategies helper to retrieve strategies by parent, category, tags, market regimes, time horizons, and required columns.

Enhancements:
- Normalize catalog YAML parent values to lowercase to align with the new ParentCatalog enum.
- Tidy existing catalog tests for brevity while preserving behavior.

Documentation:
- Add an internal GitHub agent definition file documenting an Agno-based Python agent expert profile for repository automation.

Tests:
- Add comprehensive tests covering registry construction, indexing by multiple dimensions, caching behavior, parent-based strategy listing, and multi-criteria strategy filtering.