### PR TITLE
refactoring-catalog

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Stocksense-Core"
-version = "0.10.0"
+version = "0.11.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Akash Desarda", email = "desardaakash@gmail.com" }]

--- a/core/src/stocksense/strategy/catalog/__init__.py
+++ b/core/src/stocksense/strategy/catalog/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from functools import lru_cache
 
 import yaml
 from pydantic import BaseModel
@@ -121,6 +122,7 @@ def catalog_files() -> list[Path]:
     return list(CATALOG_DIR.glob("*.yaml"))
 
 
+@lru_cache()
 def list_analysis_domains() -> AnalysisDomainIndex:
     """List available analysis domains for high-level routing."""
     domain_yaml_path = CATALOG_DIR / "domain.yaml"
@@ -130,6 +132,7 @@ def list_analysis_domains() -> AnalysisDomainIndex:
     return AnalysisDomainIndex.model_validate(data)
 
 
+@lru_cache()
 def list_strategy_catalogs() -> tuple[StrategyCatalogIndex, ...]:
     """List all strategies available in the catalog"""
 

--- a/core/src/stocksense/strategy/catalog/__init__.py
+++ b/core/src/stocksense/strategy/catalog/__init__.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -7,26 +6,6 @@ import yaml
 from pydantic import BaseModel
 
 CATALOG_DIR = Path(__file__).resolve().parent
-
-
-class ParentCatalog(Enum):
-    technical_analysis = "technical analysis"
-    # fundamental_analysis = "fundamental analysis"
-    # sentiment_analysis = "sentiment analysis"
-    # machine_learning = "machine learning"
-    # alternative_data = "alternative data"
-
-
-class CatalogCategory(Enum):
-    # Technical Analysis Categories
-    trend = "trend"
-    momentum = "momentum"
-    volatility = "volatility"
-    volume = "volume"
-    overlap = "overlap"
-    cycle = "cycle"
-    pattern = "pattern"
-    stats = "stats"
 
 
 class MarketRegime(Enum):
@@ -48,6 +27,53 @@ class TimeHorizon(Enum):
     long_term = "long term"
 
 
+# SECTION - 1. Analysis Domain Catalog
+class AnalysisDomainTypes(Enum):
+    technical_analysis = "technical analysis"
+    # fundamental_analysis = "fundamental analysis"
+    # sentiment_analysis = "sentiment analysis"
+    # machine_learning = "machine learning"
+    # alternative_data = "alternative data"
+
+
+class AnalysisDomainCategoryDescriptor(BaseModel):
+    """Metadata for a child category under a analysis domain."""
+
+    summary: str
+    use_if: list[str]
+    example_queries: list[str] | None = None
+
+
+class AnalysisDomainDescriptor(BaseModel):
+    """A descriptor for a Analysis Domain catalog, containing metadata and configuration details."""
+
+    id: AnalysisDomainTypes
+    summary: str
+    use_if: list[str]
+    avoid_when: list[str]
+    categories: dict[str, AnalysisDomainCategoryDescriptor]
+
+
+class AnalysisDomainIndex(BaseModel):
+    """Top-level analysis domain index."""
+
+    name: str
+    domains: dict[str, AnalysisDomainDescriptor]
+
+
+# SECTION - 2. Strategy Catalog
+class StrategyCategoryTypes(Enum):
+    # Technical Analysis Categories
+    trend = "trend"
+    momentum = "momentum"
+    volatility = "volatility"
+    volume = "volume"
+    overlap = "overlap"
+    cycle = "cycle"
+    pattern = "pattern"
+    stats = "stats"
+
+
 class StrategyDecisionGuidance(BaseModel):
     """Guidance for making trading decisions based on the strategy's output."""
 
@@ -61,7 +87,7 @@ class StrategyDescriptor(BaseModel):
     # Identify
     id: str
     name: str
-    category: CatalogCategory
+    category: StrategyCategoryTypes
     # Description
     summary: str
     purpose: list[str]
@@ -81,11 +107,11 @@ class StrategyDescriptor(BaseModel):
     llm_hint: str
 
 
-class StrategyCatalog(BaseModel):
+class StrategyCatalogIndex(BaseModel):
     """A catalog of trading strategies, loaded from YAML files."""
 
     name: str
-    parent: ParentCatalog
+    domain: AnalysisDomainTypes
     strategies: dict[str, StrategyDescriptor]
 
 
@@ -95,15 +121,25 @@ def catalog_files() -> list[Path]:
     return list(CATALOG_DIR.glob("*.yaml"))
 
 
-@lru_cache()
-def list_catalog() -> tuple[StrategyCatalog, ...]:
+def list_analysis_domains() -> AnalysisDomainIndex:
+    """List available analysis domains for high-level routing."""
+    domain_yaml_path = CATALOG_DIR / "domain.yaml"
+    with domain_yaml_path.open() as f:
+        data = yaml.safe_load(f)
+
+    return AnalysisDomainIndex.model_validate(data)
+
+
+def list_strategy_catalogs() -> tuple[StrategyCatalogIndex, ...]:
     """List all strategies available in the catalog"""
 
     descriptors = []
     for file in catalog_files():
+        if file.stem == "domain":
+            continue
         with file.open() as f:
             data = yaml.safe_load(f)
-            descriptor = StrategyCatalog.model_validate(data)
+            descriptor = StrategyCatalogIndex.model_validate(data)
             descriptors.append(descriptor)
     return tuple(descriptors)
 
@@ -111,51 +147,52 @@ def list_catalog() -> tuple[StrategyCatalog, ...]:
 def list_strategies() -> list[StrategyDescriptor]:
     """List all strategies available in the catalog"""
 
-    catalogs = list_catalog()
+    catalogs = list_strategy_catalogs()
     strategies = []
     for catalog in catalogs:
         strategies.extend(catalog.strategies.values())
     return strategies
 
 
-def list_strategies_by_parent(parent: str | ParentCatalog) -> list[StrategyDescriptor]:
-    """List all strategies in the catalog that belong to a specific parent"""
-    if isinstance(parent, str):
-        normalized_parent = parent.strip().lower()
+def list_strategies_by_domain(
+    domain: str | AnalysisDomainTypes,
+) -> list[StrategyDescriptor]:
+    """List all strategies in the catalog that belong to a specific domain"""
+    if isinstance(domain, str):
+        normalized_domain = domain.strip().lower()
         try:
-            parent = ParentCatalog(normalized_parent)
+            domain = AnalysisDomainTypes(normalized_domain)
         except ValueError as exc:
-            valid_values = ", ".join(p.value for p in ParentCatalog)
+            valid_values = ", ".join(p.value for p in AnalysisDomainTypes)
             raise ValueError(
-                f"Invalid parent catalog '{parent}'. "
-                f"Expected one of: {valid_values}"
+                f"Invalid analysis domain '{domain}'. Expected one of: {valid_values}"
             ) from exc
 
-    catalogs = list_catalog()
+    catalogs = list_strategy_catalogs()
     strategies = []
     for catalog in catalogs:
-        if catalog.parent == parent:
+        if catalog.domain == domain:
             strategies.extend(catalog.strategies.values())
     return strategies
 
 
 def list_strategies_by_category(
-    category: CatalogCategory | str,
+    category: StrategyCategoryTypes | str,
 ) -> list[StrategyDescriptor]:
     """List all strategies in the catalog that belong to a specific category"""
 
     if isinstance(category, str):
-        category = CatalogCategory(category)
+        category = StrategyCategoryTypes(category)
 
     strategies = list_strategies()
     return [s for s in strategies if s.category == category]
 
 
-def get_catalog_strategy_id_map() -> dict[CatalogCategory, list[str]]:
+def get_strategy_catalog_id_map() -> dict[StrategyCategoryTypes, list[str]]:
     """Get a mapping of catalog categories to the IDs of strategies that belong to each category"""
 
-    catalogs = list_catalog()
-    category_map: dict[CatalogCategory, list[str]] = {}
+    catalogs = list_strategy_catalogs()
+    category_map: dict[StrategyCategoryTypes, list[str]] = {}
     for catalog in catalogs:
         for strategy in catalog.strategies.values():
             category_map.setdefault(strategy.category, []).append(strategy.id)

--- a/core/src/stocksense/strategy/catalog/domain.yaml
+++ b/core/src/stocksense/strategy/catalog/domain.yaml
@@ -1,0 +1,124 @@
+name: Analysis Domain Catalog
+domains:
+  technical_analysis:
+    id: technical analysis
+    summary: >
+      Uses OHLCV market data, price action, volume, indicators, and derived signals
+      to analyze trend, momentum, volatility, volume participation, and price structure.
+    use_if:
+      - user asks about price trend, momentum, volatility, support/resistance, overbought/oversold, breakouts, reversals, or volume confirmation
+      - user provides or references OHLC or OHLCV data
+      - user asks what indicators or technical strategy should be applied
+    avoid_when:
+      - user asks about company revenue, earnings, valuation, balance sheet, or financial statements
+      - user asks about news, social media, analyst sentiment, or macro narrative without price-data analysis
+      - user asks to evaluate strategy profitability over historical trades, unless combined with backtesting
+    categories:
+      trend:
+        summary: >
+          Determines trend direction, trend strength, trend continuation, or trend reversal.
+        use_if:
+          - user asks whether price is bullish, bearish, trending, reversing, or continuing
+          - user asks for moving averages, MACD, ADX, DMI, or crossover analysis
+        example_queries:
+          - Is this stock in an uptrend?
+          - Is the trend weakening?
+          - Did the moving averages turn bullish?
+      momentum:
+        summary: >
+          Measures speed and exhaustion of recent price movement using oscillators.
+        use_if:
+          - user asks whether stock is overbought or oversold
+          - user asks about momentum exhaustion, short-term turning points, RSI, stochastic, or MFI
+        example_queries:
+          - Is this stock overbought?
+          - Is momentum fading?
+          - Should I use RSI here?
+      volatility:
+        summary: >
+          Measures price range expansion, contraction, and risk context.
+        use_if:
+          - user asks how volatile the stock is
+          - user asks about ATR, risk sizing, stop loss distance, or breakout volatility
+        example_queries:
+          - How volatile is this stock?
+          - What ATR-based stop should I consider?
+          - Is volatility expanding?
+      volume:
+        summary: >
+          Evaluates whether price movement is supported by volume or participation.
+        use_if:
+          - user asks whether a move is supported by volume
+          - user asks about accumulation, distribution, OBV, money flow, or participation
+        example_queries:
+          - Is this rally supported by volume?
+          - Is there accumulation?
+          - Is volume confirming the breakout?
+      overlap:
+        summary: >
+          Uses price overlays such as bands and moving-average envelopes to frame price stretch.
+        use_if:
+          - user asks whether price is stretched relative to recent range
+          - user asks about Bollinger Bands, envelopes, bands, or mean-reversion context
+        example_queries:
+          - Is price stretched above its normal range?
+          - Is this a Bollinger Band squeeze?
+          - Is price near the upper band?
+
+#  fundamental_analysis:
+#    id: fundamental analysis
+#    name: Fundamental Analysis
+#    summary: >
+#      Uses company financials, valuation, earnings, balance sheet, cash flow,
+#      growth, margins, and business quality to analyze investment merit.
+#    use_if:
+#      - user asks about valuation, revenue, earnings, margins, debt, profitability, or financial health
+#      - user asks whether a company is fundamentally strong or undervalued
+#    avoid_when:
+#      - user only provides OHLCV data and asks about price movement
+#    required_data:
+#      - financial statements
+#      - company fundamentals
+#    optional_data:
+#      - analyst estimates
+#      - sector benchmarks
+#    categories: {}
+#
+#  sentiment_analysis:
+#    id: sentiment analysis
+#    name: Sentiment Analysis
+#    summary: >
+#      Uses news, social media, analyst commentary, filings, market narratives,
+#      and text data to evaluate market perception.
+#    use_if:
+#      - user asks about market sentiment, news impact, social media mood, analyst views, or narrative
+#      - user provides articles, posts, headlines, or text snippets
+#    avoid_when:
+#      - user only asks for indicator-based OHLCV analysis
+#    required_data:
+#      - text data
+#    optional_data:
+#      - news timestamps
+#      - source credibility
+#    categories: {}
+#
+#  backtesting:
+#    id: backtesting
+#    name: Backtesting
+#    summary: >
+#      Tests a trading rule or strategy over historical data to estimate historical
+#      performance, drawdown, win rate, return, and risk metrics.
+#    use_if:
+#      - user asks whether a strategy would have worked historically
+#      - user asks about performance, win rate, drawdown, Sharpe ratio, returns, or historical simulation
+#      - user provides explicit entry and exit rules
+#    avoid_when:
+#      - user asks only which indicator to inspect without requesting performance testing
+#    required_data:
+#      - historical OHLCV data
+#      - strategy rules
+#    optional_data:
+#      - transaction costs
+#      - slippage assumptions
+#      - benchmark data
+#    categories: {}

--- a/core/src/stocksense/strategy/catalog/momentum.yaml
+++ b/core/src/stocksense/strategy/catalog/momentum.yaml
@@ -1,6 +1,6 @@
 # Curated momentum strategy metadata for AI-assisted strategy selection.
 name: Momentum Strategy Catalog
-parent: technical analysis
+domain: technical analysis
 strategies:
   rsi:
     id: momentum.rsi

--- a/core/src/stocksense/strategy/catalog/overlap.yaml
+++ b/core/src/stocksense/strategy/catalog/overlap.yaml
@@ -1,6 +1,6 @@
 # Curated overlap-study metadata for AI-assisted strategy selection.
 name: Overlap Study Strategy Catalog
-parent: technical analysis
+domain: technical analysis
 strategies:
   bbands:
     id: overlap.bbands

--- a/core/src/stocksense/strategy/catalog/registry.py
+++ b/core/src/stocksense/strategy/catalog/registry.py
@@ -2,14 +2,16 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from . import (
-    CatalogCategory,
+    StrategyCategoryTypes,
     MarketRegime,
-    ParentCatalog,
-    StrategyCatalog,
+    AnalysisDomainTypes,
+    StrategyCatalogIndex,
     StrategyDescriptor,
     TimeHorizon,
-    list_catalog,
+    list_analysis_domains,
+    list_strategy_catalogs,
     list_strategies,
+    AnalysisDomainIndex,
 )
 
 
@@ -17,11 +19,12 @@ from . import (
 class StrategyRegistry:
     """Compiled runtime view of the strategy catalog."""
 
-    catalogs: tuple[StrategyCatalog, ...]
+    domains: AnalysisDomainIndex
+    strategy_catalogs: tuple[StrategyCatalogIndex, ...]
     strategies: tuple[StrategyDescriptor, ...]
-    by_parent: dict[ParentCatalog, tuple[StrategyCatalog, ...]]
+    by_domain: dict[AnalysisDomainTypes, tuple[StrategyCatalogIndex, ...]]
+    by_strategy_category: dict[StrategyCategoryTypes, tuple[StrategyDescriptor, ...]]
     by_id: dict[str, StrategyDescriptor]
-    by_category: dict[CatalogCategory, tuple[StrategyDescriptor, ...]]
     by_tag: dict[str, tuple[StrategyDescriptor, ...]]
     by_market_regime: dict[MarketRegime, tuple[StrategyDescriptor, ...]]
     by_time_horizon: dict[TimeHorizon, tuple[StrategyDescriptor, ...]]
@@ -31,20 +34,21 @@ class StrategyRegistry:
 def build_registry() -> StrategyRegistry:
     """Build a compiled registry from the loaded strategy catalogs."""
 
-    catalogs = tuple(list_catalog())
+    domains = list_analysis_domains()
+    catalogs = tuple(list_strategy_catalogs())
     strategies = tuple(list_strategies())
-    by_parent_lists: dict[ParentCatalog, list[StrategyCatalog]] = {}
+    by_domain_lists: dict[AnalysisDomainTypes, list[StrategyCatalogIndex]] = {}
     for catalog in catalogs:
-        by_parent_lists.setdefault(catalog.parent, []).append(catalog)
+        by_domain_lists.setdefault(catalog.domain, []).append(catalog)
 
-    by_parent = {
-        parent: tuple(parent_catalogs)
-        for parent, parent_catalogs in by_parent_lists.items()
+    by_domain_index = {
+        domain: tuple(domain_catalogs)
+        for domain, domain_catalogs in by_domain_lists.items()
     }
 
     by_id = {strategy.id: strategy for strategy in strategies}
 
-    by_category_lists: dict[CatalogCategory, list[StrategyDescriptor]] = {}
+    by_category_lists: dict[StrategyCategoryTypes, list[StrategyDescriptor]] = {}
     for strategy in strategies:
         by_category_lists.setdefault(strategy.category, []).append(strategy)
 
@@ -84,11 +88,12 @@ def build_registry() -> StrategyRegistry:
     }
 
     return StrategyRegistry(
-        catalogs=catalogs,
+        domains=domains,
+        strategy_catalogs=catalogs,
         strategies=strategies,
-        by_parent=by_parent,
+        by_domain=by_domain_index,
         by_id=by_id,
-        by_category=by_category,
+        by_strategy_category=by_category,
         by_tag=by_tag,
         by_market_regime=by_market_regime,
         by_time_horizon=by_time_horizon,
@@ -105,8 +110,8 @@ def get_registry() -> StrategyRegistry:
 
 def filter_strategies(
     *,
-    parent: ParentCatalog | str | None = None,
-    category: CatalogCategory | str | None = None,
+    domain: AnalysisDomainTypes | str | None = None,
+    category: StrategyCategoryTypes | str | None = None,
     tags: list[str] | None = None,
     market_regimes: list[MarketRegime | str] | None = None,
     time_horizons: list[TimeHorizon | str] | None = None,
@@ -117,24 +122,24 @@ def filter_strategies(
     registry = get_registry()
     strategies: tuple[StrategyDescriptor, ...] = registry.strategies
 
-    if parent is not None:
-        if isinstance(parent, str):
-            parent = ParentCatalog(parent.strip().lower())
-        parent_catalogs = registry.by_parent.get(parent, ())
-        parent_strategy_ids = {
+    if domain is not None:
+        if isinstance(domain, str):
+            domain = AnalysisDomainTypes(domain.strip().lower())
+        domain_catalogs = registry.by_domain.get(domain, ())
+        domain_strategy_ids = {
             strategy.id
-            for catalog in parent_catalogs
+            for catalog in domain_catalogs
             for strategy in catalog.strategies.values()
         }
         strategies = tuple(
-            strategy for strategy in strategies if strategy.id in parent_strategy_ids
+            strategy for strategy in strategies if strategy.id in domain_strategy_ids
         )
 
     if category is not None:
         if isinstance(category, str):
-            category = CatalogCategory(category.strip().lower())
+            category = StrategyCategoryTypes(category.strip().lower())
         category_strategy_ids = {
-            strategy.id for strategy in registry.by_category.get(category, ())
+            strategy.id for strategy in registry.by_strategy_category.get(category, ())
         }
         strategies = tuple(
             strategy for strategy in strategies if strategy.id in category_strategy_ids

--- a/core/src/stocksense/strategy/catalog/trend.yaml
+++ b/core/src/stocksense/strategy/catalog/trend.yaml
@@ -1,7 +1,7 @@
 # Curated trend strategy metadata for AI-assisted strategy selection.
 # Contributors should keep field names stable so the Python loader can validate them.
 name: Trend Strategy Catalog
-parent: technical analysis
+domain: technical analysis
 strategies:
   sma_crossover:
     id: trend.sma_crossover

--- a/core/src/stocksense/strategy/catalog/volatility.yaml
+++ b/core/src/stocksense/strategy/catalog/volatility.yaml
@@ -1,6 +1,6 @@
 # Curated volatility strategy metadata for AI-assisted strategy selection.
 name: Volatility Strategy Catalog
-parent: technical analysis
+domain: technical analysis
 strategies:
   atr:
     id: volatility.atr

--- a/core/src/stocksense/strategy/catalog/volume.yaml
+++ b/core/src/stocksense/strategy/catalog/volume.yaml
@@ -1,6 +1,6 @@
 # Curated volume strategy metadata for AI-assisted strategy selection.
 name: Volume Strategy Catalog
-parent: technical analysis
+domain: technical analysis
 strategies:
   obv:
     id: volume.obv

--- a/core/tests/tests_strategy/test_catalog.py
+++ b/core/tests/tests_strategy/test_catalog.py
@@ -1,12 +1,15 @@
 import pytest
 from stocksense.strategy.catalog import (
-    CatalogCategory,
+    StrategyCategoryTypes,
+    AnalysisDomainTypes,
     catalog_files,
-    get_catalog_strategy_id_map,
+    get_strategy_catalog_id_map,
     get_strategy_by_id,
-    list_catalog,
+    list_analysis_domains,
+    list_strategy_catalogs,
     list_strategies,
     list_strategies_by_category,
+    list_strategies_by_domain,
 )
 
 
@@ -16,9 +19,8 @@ def test_strategy_catalog_files_exist():
 
 
 def test_strategy_catalog_loads_all_yaml_files():
-    catalogs = list_catalog()
-    assert catalogs
-    assert len(catalogs) == len(catalog_files())
+    catalogs = list_strategy_catalogs()
+    assert len(catalogs) == len(catalog_files()) - 1
 
     strategies = list_strategies()
     assert strategies
@@ -46,12 +48,12 @@ def test_strategy_catalog_required_fields_are_present():
         assert descriptor.llm_hint
 
 
-@pytest.mark.parametrize("category", [CatalogCategory.trend, "trend"])
+@pytest.mark.parametrize("category", [StrategyCategoryTypes.trend, "trend"])
 def test_list_strategies_by_category_returns_only_matching_strategies(category):
     strategies = list_strategies_by_category(category)
 
     assert strategies
-    assert all(strategy.category == CatalogCategory.trend for strategy in strategies)
+    assert all(strategy.category == StrategyCategoryTypes.trend for strategy in strategies)
 
 
 def test_list_strategies_by_category_rejects_unknown_category():
@@ -59,8 +61,28 @@ def test_list_strategies_by_category_rejects_unknown_category():
         list_strategies_by_category("unknown")
 
 
+def test_list_analysis_domains_returns_all_domains():
+    index = list_analysis_domains()
+    assert index.domains
+    assert any(domain.id == AnalysisDomainTypes.technical_analysis for domain in index.domains.values())
+
+
+@pytest.mark.parametrize("domain", [AnalysisDomainTypes.technical_analysis, "technical analysis"])
+def test_list_strategies_by_domain_returns_only_matching_strategies(domain):
+    strategies = list_strategies_by_domain(domain)
+
+    assert strategies
+    # Since all current strategies are technical analysis
+    assert len(strategies) == len(list_strategies())
+
+
+def test_list_strategies_by_domain_rejects_unknown_domain():
+    with pytest.raises(ValueError):
+        list_strategies_by_domain("unknown")
+
+
 def test_get_catalog_strategy_id_map_matches_loaded_strategies():
-    category_map = get_catalog_strategy_id_map()
+    category_map = get_strategy_catalog_id_map()
     strategies = list_strategies()
 
     assert category_map

--- a/core/tests/tests_strategy/test_catalog_registry.py
+++ b/core/tests/tests_strategy/test_catalog_registry.py
@@ -1,11 +1,11 @@
 from stocksense.strategy.catalog import (
-    CatalogCategory,
+    StrategyCategoryTypes,
     MarketRegime,
-    ParentCatalog,
+    AnalysisDomainTypes,
     TimeHorizon,
-    list_catalog,
+    list_strategy_catalogs,
     list_strategies,
-    list_strategies_by_parent,
+    list_strategies_by_domain,
 )
 from stocksense.strategy.catalog.registry import (
     StrategyRegistry,
@@ -19,25 +19,25 @@ def test_build_registry_compiles_catalogs_and_indexes():
     registry = build_registry()
 
     assert isinstance(registry, StrategyRegistry)
-    assert registry.catalogs == list_catalog()
+    assert registry.strategy_catalogs == list_strategy_catalogs()
     assert registry.strategies == tuple(list_strategies())
-    assert registry.by_parent
+    assert registry.by_domain
     assert registry.by_id
-    assert registry.by_category
+    assert registry.by_strategy_category
     assert registry.by_tag
     assert registry.by_market_regime
     assert registry.by_time_horizon
     assert registry.by_required_column
 
 
-def test_build_registry_indexes_catalogs_by_parent():
+def test_build_registry_indexes_catalogs_by_domain():
     registry = build_registry()
 
-    for parent, catalogs in registry.by_parent.items():
-        assert all(catalog.parent == parent for catalog in catalogs)
+    for domain, catalogs in registry.by_domain.items():
+        assert all(catalog.domain == domain for catalog in catalogs)
 
-    assert set(registry.by_parent) == {catalog.parent for catalog in registry.catalogs}
-    assert ParentCatalog.technical_analysis in registry.by_parent
+    assert set(registry.by_domain) == {catalog.domain for catalog in registry.strategy_catalogs}
+    assert AnalysisDomainTypes.technical_analysis in registry.by_domain
 
 
 def test_build_registry_indexes_strategies_by_id_and_category():
@@ -46,13 +46,13 @@ def test_build_registry_indexes_strategies_by_id_and_category():
     for strategy in registry.strategies:
         assert registry.by_id[strategy.id] == strategy
 
-    for category, strategies in registry.by_category.items():
+    for category, strategies in registry.by_strategy_category.items():
         assert all(strategy.category == category for strategy in strategies)
 
-    assert set(registry.by_category) == {
+    assert set(registry.by_strategy_category) == {
         strategy.category for strategy in registry.strategies
     }
-    assert CatalogCategory.trend in registry.by_category
+    assert StrategyCategoryTypes.trend in registry.by_strategy_category
 
 
 def test_build_registry_indexes_strategies_by_tag_regime_horizon_and_column():
@@ -85,8 +85,8 @@ def test_get_registry_returns_cached_registry_instance():
     assert first_registry is second_registry
 
 
-def test_list_strategies_by_parent_returns_matching_strategies():
-    strategies = list_strategies_by_parent("technical analysis")
+def test_list_strategies_by_domain_returns_matching_strategies():
+    strategies = list_strategies_by_domain("technical analysis")
 
     assert strategies
     assert strategies == list(list_strategies())
@@ -94,8 +94,8 @@ def test_list_strategies_by_parent_returns_matching_strategies():
 
 def test_filter_strategies_returns_intersection_of_registry_indexes():
     strategies = filter_strategies(
-        parent="technical analysis",
-        category=CatalogCategory.momentum,
+        domain="technical analysis",
+        category=StrategyCategoryTypes.momentum,
         tags=["volume-confirmation"],
         market_regimes=[MarketRegime.trending],
         time_horizons=[TimeHorizon.swing],

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -3235,7 +3235,7 @@ wheels = [
 
 [[package]]
 name = "stocksense-core"
-version = "0.10.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
# Important Changes

- Added technical analysis domain catalog
- Restructured catalog with domain index and renamed all symbols for clarity
- Renamed "parent" field to "domain" across all strategy catalog YAML files for better semantic accuracy
- Refactored catalog API:
  - Renamed `CatalogCategory` to `StrategyCategoryTypes`
  - Introduced `AnalysisDomainTypes` for domain classification
  - Renamed `list_catalog()` to `list_strategy_catalogs()`
  - Renamed `get_catalog_strategy_id_map()` to `get_strategy_catalog_id_map()`
- Added new functions: `list_analysis_domains()` and `list_strategies_by_domain()` for domain-based filtering
- Updated `StrategyRegistry` to use `by_domain` and `by_strategy_category` instead of `by_parent` and `by_category`
- Updated all tests to reflect new API changes

## Summary by Sourcery

Introduce an analysis-domain index and refactor the strategy catalog API and registry to be domain-aware, with updated naming and tests.

New Features:
- Add an analysis domain catalog with metadata and routing information for strategy domains.
- Expose new catalog queries for listing analysis domains and filtering strategies by domain.

Enhancements:
- Rename catalog models, enums, and fields to use domain-oriented terminology and clearer strategy category naming.
- Update the strategy registry structure and filter helpers to index catalogs and strategies by analysis domain and strategy category rather than the old parent/category mapping.

Tests:
- Update existing catalog and registry tests for the new API and introduce coverage for domain listing and domain-based strategy queries.